### PR TITLE
Parent menu items translations

### DIFF
--- a/resources/assets/js/pages/enso/layout/sidebar/Menus.vue
+++ b/resources/assets/js/pages/enso/layout/sidebar/Menus.vue
@@ -16,7 +16,7 @@
                 <span class="icon is-small">
                     <i :class="menu.icon"></i>
                 </span>
-                {{ menu.name }}
+                {{ __(menu.name) }}
                 <span class="icon is-small angle is-pulled-right">
                     <i class="fa fa-angle-left"></i>
                 </span>


### PR DESCRIPTION
Currently parent menu items will not be translated as they miss the __() syntax, this tiny tiny PR fixes that.