### PR TITLE
deleted max-height of multiselect tags

### DIFF
--- a/resources/assets/js/components/enso/vueforms/VueSelect.vue
+++ b/resources/assets/js/components/enso/vueforms/VueSelect.vue
@@ -255,7 +255,6 @@ export default {
 
     div.vue-select .multiselect__tags {
         min-height: 36px;
-        max-height: 36px;
         padding: 4px 40px 0 4px;
         border-radius: 3px;
 


### PR DESCRIPTION
If you have some more tags selected, they don't fit in the area.