### PR TITLE
Add pdosqlsrv options that make it behave "normal"

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -74,6 +74,10 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'charset' => 'utf8',
             'prefix' => '',
+            'options' => [
+              PDO::ATTR_STRINGIFY_FETCHES => false,
+              PDO::SQLSRV_ATTR_FETCHES_NUMERIC_TYPE => true
+            ],            
         ],
     ],
 


### PR DESCRIPTION
Found the root cause & fix ([source](https://stackoverflow.com/a/39478813/620141)) related to mssql acting out: it's pdo driver **by default** stringifies everything; including numerics.
This causes every relation to fail (as for some reason the primary key IS getting returned as an int; causing a type mismatch between the relation; causing laravel-enso to break.

This should fix this issue (instead of mitigating it with casts everywhere)