### PR TITLE
add missing @vue/cli-service

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "postinstall": "opencollective-postinstall"
     },
     "devDependencies": {
+        "@vue/cli-service": "^3.1.3",
         "@vue/eslint-config-airbnb": "^3.0.3",
         "babel-eslint": "^8.2.3",
         "babel-plugin-syntax-dynamic-import": "^6.18.0",


### PR DESCRIPTION
The missing `vue/cli-service` caused the (default) eslint to not be runnable properly