### PR TITLE
Remove link to closed PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 For existing projects check the repo's `phpunit.xml` file and make sure you have all the test suites for your instance.
 
-Note: temporarily disable the `RequestWatcher` in telescope.php (`Watchers\RequestWatcher::class => env('TELESCOPE_REQUEST_WATCHER', false)`) until the problem will be fixed -> https://github.com/laravel/telescope/pull/357
-
 ### 2.13.9
 - adds categories filtering for searchable
 


### PR DESCRIPTION
The related https://github.com/laravel/telescope/issues/354 has been closed
(not verified it fixed the Enso issue as I don't have a test case that I'm sure doesn't work)