### PR TITLE
Fix & Update broadcasting.php config

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -47,10 +47,10 @@ return [
             'secret' => env('PUSHER_APP_SECRET'),
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
-                'host' => '127.0.0.1',
-                'port' => 6001,
+                'host' => env('PUSHER_APP_HOST', '127.0.0.1'),
+                'port' => env('PUSHER_APP_PORT', 6001),
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'scheme' => 'http',
+                'scheme' => env('PUSHER_APP_SCHEME', 'http'),
             ],
         ],
 

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -47,10 +47,10 @@ return [
             'secret' => env('PUSHER_APP_SECRET'),
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
-                'host' => env('PUSHER_APP_HOST', '127.0.0.1'),
-                'port' => env('PUSHER_APP_PORT', 6001),
+                'host' => '127.0.0.1',
+                'port' => 6001,
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'scheme' => env('PUSHER_APP_SCHEME', 'http'),
+                'scheme' => 'http',
             ],
         ],
 

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -37,20 +37,7 @@ return [
                 'host' => env('PUSHER_APP_HOST', 'api.pusherapp.com'),
                 'port' => env('PUSHER_APP_PORT'),
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'scheme' => env('PUSHER_APP_SCHEME', 'https'),
-            ],
-        ],
-
-        'localpusher' => [
-            'driver' => 'pusher',
-            'key' => env('PUSHER_APP_KEY'),
-            'secret' => env('PUSHER_APP_SECRET'),
-            'app_id' => env('PUSHER_APP_ID'),
-            'options' => [
-                'host' => '127.0.0.1',
-                'port' => 6001,
-                'cluster' => env('PUSHER_APP_CLUSTER'),
-                'scheme' => 'http',
+                'encrypted' => true,
             ],
         ],
 

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -34,8 +34,23 @@ return [
             'secret' => env('PUSHER_APP_SECRET'),
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
-              'cluster' => env('PUSHER_APP_CLUSTER'),
-              'encrypted' => true,
+                'host' => env('PUSHER_APP_HOST', 'api.pusherapp.com'),
+                'port' => env('PUSHER_APP_PORT'),
+                'cluster' => env('PUSHER_APP_CLUSTER'),
+                'scheme' => env('PUSHER_APP_SCHEME', 'https'),
+            ],
+        ],
+
+        'localpusher' => [
+            'driver' => 'pusher',
+            'key' => env('PUSHER_APP_KEY'),
+            'secret' => env('PUSHER_APP_SECRET'),
+            'app_id' => env('PUSHER_APP_ID'),
+            'options' => [
+                'host' => '127.0.0.1',
+                'port' => 6001,
+                'cluster' => env('PUSHER_APP_CLUSTER'),
+                'scheme' => 'http',
             ],
         ],
 


### PR DESCRIPTION
Part of https://github.com/laravel-enso/Notifications/issues/5 (laravel-websocket support)
'localpusher' is a performance-optimizing local push which doesn't require SSL (when using laravel-websockets

Note that server-side "encrypted" should be "scheme" (see [docs](https://github.com/pusher/pusher-http-php#pusher-constructor))

Also see https://github.com/laravel-enso/Core/pull/93