### PR TITLE
Add replace note about date-fns & rewording for v3.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -577,6 +577,8 @@ if (mix.inProduction()) {
 
 - replace relative routeImporer imports such as: `import routeImporter from '../modules/importers/routeImporter;` with the package import : `import routeImporter from '@core-modules/importers/routeImporter';`
 
+- replace relative date-fns imports such as: `import format from '../../../modules/enso/plugins/date-fns/format;` with the package import `import format from '@core-modules/plugins/date-fns/format';` (notably `format`, `formatDistance`) 
+
 - comment out the import of the `tiptap-extensions` from `/resources/js/components/enso/vueforms/Wysiwyg.vue`
 
 - in `resources/images` ensure you have `earthlink.svg` & `enso-favicon.png`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -588,7 +588,8 @@ within the route file you expose only the `path` and the `children` properties. 
 
 - move the icon imports from `resources/js/core/structure/menu/icons/app.js` to `resources/js/app.js`
 
-Migrate all pages/components by looking at the general changelog
+- Migrate all pages/components by looking at the [New Packages section](#new-packages).
+
 - inject `i18n` and `errorHandler` everywhere they're used
 
 ### 2.16.3


### PR DESCRIPTION
Add replace note about date-fns move (used for custom components & in "transition" state for `resources/js/components/enso`

note: marking as draft pull until fully upgraded, to group all further missing changes/notes here. (almost through everything though, so I don't expect anything more significant missing from the changelog/upgrade steps)