### PR TITLE
 Add docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+services:
+  php:
+    build: ./docker
+    container_name: enso
+    ports:
+      - 8000:80
+    volumes:
+      - ./docker/vhosts.conf:/etc/apache2/sites-enabled/000-default.conf
+      - ./:/var/www/html
+    depends_on:
+      - mysqldb
+
+  mysqldb:
+    image: mysql:5.7.21
+    container_name: enso-${DB_CONNECTION}
+    restart: always
+    env_file:
+      - .env
+    environment:
+      - MYSQL_DATABASE=${DB_DATABASE}
+      - MYSQL_USER=${DB_USERNAME}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+      - MYSQL_ALLOW_EMPTY_PASSWORD=true
+    ports:
+      - 3306:3306
+    volumes:
+      - /var/lib/mysql
+
+#  myadmin:
+#    image: phpmyadmin/phpmyadmin:4.7
+#    container_name: enso-phpmyadmin
+#    ports:
+#      - 8081:80
+#    environment:
+#      - PMA_ARBITRARY=1
+#      - PMA_HOST=${DB_CONNECTION}
+#    restart: always
+#    depends_on:
+#      - mysqldb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM php:7.3-apache
+LABEL maintainer="Patrick Greene <patrick@vsteks.com>"
+
+# Apache configuration
+RUN a2enmod rewrite
+
+# Install dependencies
+RUN apt-get update \
+  && apt-get install -y zlib1g-dev libicu-dev wget gnupg g++ git openssh-client \
+  && apt-get install -y libxml2-dev libfreetype6-dev libpng-dev libjpeg-dev libzip-dev \
+  && apt-get install -y libmagickwand-dev \
+  && docker-php-ext-configure intl \
+  && docker-php-ext-install intl pdo_mysql zip
+
+# clean
+RUN rm -rf /var/cache/apk/*
+
+# Install php extensions.
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include
+RUN docker-php-ext-install bcmath intl zip pcntl soap gd
+
+# Enable imagick
+RUN pecl install imagick-3.4.3
+RUN echo "extension=imagick.so" >> /usr/local/etc/php/conf.d/imagick.ini
+
+# Install xdebug
+RUN pecl install xdebug-2.7.0RC2 && docker-php-ext-enable xdebug
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+#Install Yarn
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+RUN apt-get update \
+  && apt-get install -y nodejs \
+  && apt-get install -y yarn

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
 FROM php:7.3-apache
-LABEL maintainer="Patrick Greene <patrick@vsteks.com>"
 
 # Apache configuration
 RUN a2enmod rewrite

--- a/docker/vhosts.conf
+++ b/docker/vhosts.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+  ServerAdmin webmaster@localhost
+  DocumentRoot /var/www/html/public
+
+  <Directory /var/www/html/>
+      Options Indexes FollowSymLinks MultiViews
+      AllowOverride All
+      Order deny,allow
+      Allow from all
+  </Directory>
+
+  ErrorLog ${APACHE_LOG_DIR}/error.log
+  CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+</VirtualHost>


### PR DESCRIPTION
This PR is more of a question. Would you consider adding a docker config to the enso library? I decided to make this a PR as opposed to an issue becuase then i can show you the current config im using for docker.

As written the user must run 

`docker-compose up --build -d` (Or just `docker-compose up`)

After it's done building you must set permissions  so that the docker user www-data can write to the files like so.

`chown -R www-data:www-data /var/www/html/`

After that simple follow the normal Enso install process but inside the 'enso' container

To open a bash shell in the enso container
`docker exec -it enso bash`