### PR TITLE
Fix typo in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 #      - 8081:80
 #    environment:
 #      - PMA_ARBITRARY=1
-#      - PMA_HOST=${DB_CONNECTION}
+#      - PMA_HOST=enso-${DB_CONNECTION}
 #    restart: always
 #    depends_on:
 #      - mysqldb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN a2enmod rewrite
 RUN apt-get update \
   && apt-get install -y zlib1g-dev libicu-dev wget gnupg g++ git openssh-client \
   && apt-get install -y libxml2-dev libfreetype6-dev libpng-dev libjpeg-dev libzip-dev \
-  && apt-get install -y libmagickwand-dev \
+  && apt-get install -y libmagickwand-dev unzip\
   && docker-php-ext-configure intl \
   && docker-php-ext-install intl pdo_mysql zip
 


### PR DESCRIPTION
The phpmyadmin container was using the wrong hostname as PWA_HOST variable. Also install unzip in the docker container to quite a composer error.