### PR TITLE
Add Spanish language to migrations

### DIFF
--- a/database/seeds/LanguageSeeder.php
+++ b/database/seeds/LanguageSeeder.php
@@ -16,6 +16,7 @@ class LanguageSeeder extends Seeder
         ['name' => 'ar', 'display_name' => 'Arabic', 'flag' => 'flag-icon flag-icon-eg', 'is_rtl' => true, 'is_active' => true],
         ['name' => 'mn', 'display_name' => 'Mongolia', 'flag' => 'flag-icon flag-icon-mn', 'is_rtl' => false, 'is_active' => true],
         ['name' => 'hu', 'display_name' => 'Magyar', 'flag' => 'flag-icon flag-icon-hu', 'is_rtl' => false, 'is_active' => true],
+        ['name' => 'es', 'display_name' => 'Español', 'flag' => 'flag-icon flag-icon-es', 'is_rtl' => false, 'is_active' => true],
     ];
 
     public function run()


### PR DESCRIPTION
The translation files were already added beforehand but since they are not in the database with the installation it is not possible to select them.