### PR TITLE
Client configurations outdated(vue.config.js) #372

### DIFF
--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -37,7 +37,7 @@ module.exports = {
         devtool: inProduction ? 'hidden-source-map' : 'source-map',
         resolve: {
             alias: {
-                '@core': `${__dirname}/node_modules/@enso-ui/ui/src`,
+                '@ui': `${__dirname}/node_modules/@enso-ui/ui/src`,
                 '@root': `${__dirname}/src/js`,
                 '@pages': `${__dirname}/src/js/pages`,
                 '@store': `${__dirname}/src/js/store`,

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -51,12 +51,17 @@ module.exports = {
                 release: process.env.SENTRY_RELEASE,
                 ignore: ['vendor'],
             }),
-            new CopyPlugin([{
-                from: '../resources/images',
-                to: 'images',
-                force: true,
-                folder: true,
-            }]),
+            new CopyPlugin(
+                {
+                    patterns: [
+                        {
+                            from: '../resources/images',
+                            to: 'images',
+                            force: true,
+                        },
+                    ],
+                },
+            ),
         ].filter(p => p),
     },
     chainWebpack: config => {


### PR DESCRIPTION
- updated outdated package alias from @core to @ui according to Release notes from 4.4.0: 'the @core alias has been renamed to @ui, so update all usages ...'